### PR TITLE
added http digest auth support

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,5 @@
 AUTOMAKE_OPTIONS = no-dependencies
 AM_CPPFLAGS = -I$(srcdir)
 bin_PROGRAMS = corkscrew
-corkscrew_SOURCES = corkscrew.c
+corkscrew_SOURCES = corkscrew.c md5.c
+AM_LDFLAGS = -levent

--- a/corkscrew.c
+++ b/corkscrew.c
@@ -11,7 +11,8 @@
 #include <sys/time.h>
 #include <sys/types.h>
 #include <unistd.h>
-
+#include <event.h>  
+#include "md5.h"
 #if HAVE_SYS_FILIO_H
 #include <sys/filio.h>
 #endif
@@ -34,7 +35,7 @@ int main PARAMS((int argc, char *argv[]));
 /*
 char linefeed[] = "\x0A\x0D\x0A\x0D";
 */
-char linefeed[] = "\r\n\r\n"; /* it is better and tested with oops & squid */
+char linefeed[] = "\r\n"; /* it is better and tested with oops & squid */
 
 /*
 ** base64.c
@@ -161,6 +162,166 @@ int port;
 	return fd;
 }
 
+#define MD5_HASHLEN (16)
+static void dump_hash(char *buf, const unsigned char *hash) 
+{
+	int i;
+
+	for (i = 0; i < MD5_HASHLEN; i++) {
+		buf += sprintf(buf, "%02x", hash[i]);
+	}
+
+	*buf = 0;
+}
+
+/*
+	Taken from darkk/redsocks
+*/
+uint32_t red_randui32()
+{
+	uint32_t ret;
+	evutil_secure_rng_get_bytes(&ret, sizeof(ret));
+	return ret;
+}
+
+/*
+	Based on the corresponding function on darkk/redsocks
+*/
+
+char* digest_authentication_encode(char* user, char* realm, char* passwd, char * method, char * path, char* nc, char* nonce, char* cnonce, char* qop){
+
+	
+	/* calculate the digest value */
+	md5_state_t ctx;
+	md5_byte_t hash[MD5_HASHLEN];
+	char a1buf[MD5_HASHLEN * 2 + 1], a2buf[MD5_HASHLEN * 2 + 1];
+	char response[MD5_HASHLEN * 2 + 1];
+	/* A1 = username-value ":" realm-value ":" passwd */
+	md5_init(&ctx);
+	md5_append(&ctx, (md5_byte_t*)user, strlen(user));
+	md5_append(&ctx, (md5_byte_t*)":", 1);
+	md5_append(&ctx, (md5_byte_t*)realm, strlen(realm));
+	md5_append(&ctx, (md5_byte_t*)":", 1);
+	md5_append(&ctx, (md5_byte_t*)passwd, strlen(passwd));
+	md5_finish(&ctx, hash);
+	dump_hash(a1buf, hash);
+
+	/* A2 = Method ":" digest-uri-value */
+	
+	md5_init(&ctx);
+	md5_append(&ctx, (md5_byte_t*)method, strlen(method));
+	md5_append(&ctx, (md5_byte_t*)":", 1);
+	md5_append(&ctx, (md5_byte_t*)path, strlen(path));
+	md5_finish(&ctx, hash);
+	dump_hash(a2buf, hash);
+	
+	
+	
+	
+	/* qop set: request-digest = H(A1) ":" nonce-value ":" nc-value ":" cnonce-value ":" qop-value ":" H(A2) */
+	/* not set: request-digest = H(A1) ":" nonce-value ":" H(A2) */
+	md5_init(&ctx);
+	md5_append(&ctx, (md5_byte_t*)a1buf, strlen(a1buf));
+	md5_append(&ctx, (md5_byte_t*)":", 1);
+	md5_append(&ctx, (md5_byte_t*)nonce, strlen(nonce));
+	md5_append(&ctx, (md5_byte_t*)":", 1);
+	if (qop) {
+		md5_append(&ctx, (md5_byte_t*)nc, strlen(nc));
+		md5_append(&ctx, (md5_byte_t*)":", 1);
+		md5_append(&ctx, (md5_byte_t*)cnonce, strlen(cnonce));
+		md5_append(&ctx, (md5_byte_t*)":", 1);
+		md5_append(&ctx, (md5_byte_t*)qop, strlen(qop));
+		md5_append(&ctx, (md5_byte_t*)":", 1);
+	}
+	md5_append(&ctx, (md5_byte_t*)a2buf, strlen(a2buf));
+	md5_finish(&ctx, hash);
+	dump_hash(response, hash);
+
+	/* prepare the final string */
+	int len = 256;
+	len += strlen(user);
+	len += strlen(realm);
+	len += strlen(nonce);
+	len += strlen(path);
+	len += strlen(response);
+
+	if (qop) {
+		len += strlen(qop);
+		len += strlen(nc);
+		len += strlen(cnonce);
+	}
+
+	char *res = (char*)malloc(len);
+	if(qop)
+		sprintf(res, "username=\"%s\", realm=\"%s\", nonce=\"%s\", uri=\"%s\", response=\"%s\", qop=%s, nc=%s, cnonce=\"%s\"",
+			user, realm, nonce, path, response, qop, nc, cnonce);
+	else
+		sprintf(res, "username=\"%s\", realm=\"%s\", nonce=\"%s\", uri=\"%s\", response=\"%s\"",
+			user, realm, nonce, path, response);
+	
+	return res;
+}
+
+typedef struct proxyauth{
+	char realm[BUFSIZE];
+	char nonce[33];
+	char qop[BUFSIZE];
+	int stale;
+}proxyauth;
+
+
+proxyauth* process_line(char* line){
+	
+	proxyauth* pa = (proxyauth *)malloc(sizeof(proxyauth));
+	// for now only looking for nonce, realm and qop
+	char* where = strstr(line, "nonce=");
+	if(where != NULL)strncpy(pa->nonce, where + 7, 32);
+	where = strstr(line, "realm=");
+	if(where != NULL)sscanf(where + 7, "%[^\"]", pa->realm);
+	where = strstr(line, "qop=");
+	if(where != NULL)sscanf(where + 5, "%[^\"]", pa->qop);
+	// only 'auth' parameter is recognized
+	if(strstr(pa->qop, "auth") == NULL)pa->qop[0] = '\0'; 
+	else strncpy(pa->qop, "auth", 5);
+	return pa;
+}
+
+
+proxyauth * get_param(char * buffer){
+	char line[BUFSIZE] = "";
+	int cur = 0;
+	int blen = strlen(buffer);
+	const char pauth[20] = "Proxy-Authenticate:";
+	const char conclose[18] = "Connection: close";
+	while(cur < blen){
+		sscanf(buffer + cur, " %[^\n]", line);
+		
+		cur += strlen(line) + 1;
+		
+		if(strncmp(line, pauth, strlen(pauth)) == 0){
+			return process_line(line);
+		}
+		if(strncmp(line, conclose, strlen(conclose)) == 0)break;
+	}
+	return NULL;
+	
+}
+#define min(a, b) ((a) < (b) ? (a) : (b))
+char * header(char * buffer){
+	char * where = strstr(buffer, "\r\n\r\n");
+	int headlen = 2048;
+	char *head = (char*)malloc(2048);
+	memset(head, 0, headlen);
+	if(where==NULL){
+		return head;
+	}
+	else{
+		strncat(head, buffer, min(where - buffer, headlen - 1));
+		return head;
+	}
+}
+
+
 #ifdef ANSI_FUNC
 int main (int argc, char *argv[])
 #else
@@ -181,8 +342,16 @@ char *argv[];
 	struct timeval tv;
 	ssize_t len;
 	FILE *fp;
-
-	port = 80;
+	char line[BUFSIZE];
+	char uri_path[256] = "";
+	int debug;
+	int n_file_descriptor;
+	int nc = 1;
+	char prev_nonce[33] = "";
+	int reading = 0;
+	
+	debug = 0;
+	port = 443;
 
 	if ((argc == 5) || (argc == 6)) {
 		if (argc == 5) {
@@ -201,7 +370,7 @@ char *argv[];
 				fprintf(stderr, "Error opening %s: %s\n", argv[5], strerror(errno));
 				exit(-1);
 			} else {
-				char line[4096];
+				
 				fscanf(fp, "%s", line);
 				up = malloc(sizeof(line));
 				up = line;
@@ -212,21 +381,29 @@ char *argv[];
 		usage();
 		exit(-1);
 	}
-
-	strncpy(uri, "CONNECT ", sizeof(uri));
-	strncat(uri, desthost, sizeof(uri) - strlen(uri) - 1);
-	strncat(uri, ":", sizeof(uri) - strlen(uri) - 1);
-	strncat(uri, destport, sizeof(uri) - strlen(uri) - 1);
-	strncat(uri, " HTTP/1.0", sizeof(uri) - strlen(uri) - 1);
-	if ((argc == 6) || (argc == 7)) {
-		strncat(uri, "\nProxy-Authorization: Basic ", sizeof(uri) - strlen(uri) - 1);
-		strncat(uri, base64_encode(up), sizeof(uri) - strlen(uri) - 1);
-	}
-	strncat(uri, linefeed, sizeof(uri) - strlen(uri) - 1);
+	memset(uri, 0, sizeof(uri));
+	
+	memset(uri_path, 0, sizeof(uri_path));
+	strcat(uri_path, desthost);
+	strcat(uri_path, ":");
+	strcat(uri_path, destport);
+	
+	strcat(uri, "CONNECT ");
+	strcat(uri, uri_path);
+	strcat(uri, " HTTP/1.1");
+	strcat(uri, linefeed);
+	
+	strcat(uri, "Host: ");
+	strcat(uri, uri_path);
+	strcat(uri, linefeed);
+	
+	strcat(uri, "Proxy-Connection: Keep-Alive");
+	strcat(uri, linefeed);
+	strcat(uri, linefeed);
 
 	csock = sock_connect(host, port);
 	if(csock == -1) {
-		fprintf(stderr, "Couldn't establish connection to proxy: %s\n", strerror(errno));
+		fprintf(stderr, "Error: Couldn't establish connection to proxy: %s\n", strerror(errno));
 		exit(-1);
 	}
 
@@ -243,37 +420,181 @@ char *argv[];
 
 		tv.tv_sec = 5;
 		tv.tv_usec = 0;
-
-		if(select(csock+1,&rfd,&sfd,NULL,&tv) == -1) break;
+		n_file_descriptor = select(csock+1,&rfd,&sfd,NULL,&tv);
+		if(debug & 1)fprintf(stderr, "DEBUG: n_file_descriptor = %d\n", n_file_descriptor);
+		if(n_file_descriptor == 0)continue;
+		if(n_file_descriptor == -1) break;
 
 		/* there's probably a better way to do this */
 		if (setup == 0) {
+			
 			if (FD_ISSET(csock, &rfd)) {
+				memset(buffer, 0, sizeof(buffer));
 				len = read(csock, buffer, sizeof(buffer));
-				if (len<=0)
-					break;
+				
+				if (len <= 0)	break;
 				else {
+					if(reading == 1)continue;
+					reading = 1;
 					sscanf(buffer,"%s%d%[^\n]",version,&code,descr);
+					if(debug & 1)fprintf(stderr, "DEBUG: version = %s code = %d\n", version, code);
+					if(debug & 1)fprintf(stderr, "DEBUG: header = %s\n", header(buffer));
+					if(debug & 1)fprintf(stderr, "DEBUG: len = %d\n", len);
 					if ((strncmp(version,"HTTP/",5) == 0) && (code >= 200) && (code < 300))
 						setup = 1;
 					else {
 						if ((strncmp(version,"HTTP/",5) == 0) && (code >= 407)) {
 						}
-						fprintf(stderr, "Proxy could not open connnection to %s: %s\n", desthost, descr);
+						if (code == 407) {
+							
+							if(strstr(buffer, "Digest realm") != NULL){
+								if(debug & 1)fprintf(stderr, "DEBUG: Digest auth needed\n");
+								proxyauth* pa = get_param(buffer);
+								if(pa == NULL){
+									fprintf(stderr, "Error: Proxy response contains errors\n");
+									exit(-1);
+								}
+								if(strlen(pa->nonce) != 32){
+									fprintf(stderr, "Error: Proxy response contains errors (nonce)\n");
+									exit(-1);
+								}
+								memset(uri, 0, sizeof(uri));
+								
+								strcat(uri, "CONNECT ");
+								strcat(uri, uri_path);
+								strcat(uri, " HTTP/1.1");
+								strcat(uri, linefeed);
+								
+								strcat(uri, "Host: ");
+								strcat(uri, uri_path);
+								strcat(uri, linefeed);
+								
+								strcat(uri, "Proxy-Connection: Keep-Alive");
+								strcat(uri, linefeed);
+								
+								if ((argc == 6) || (argc == 7)) {
+									char user[256] = "";
+									sscanf(up, "%[^:]", user);
+									char passwd[256] = "";
+									sscanf(up + strlen(user) + 1, "%s", passwd);
+									char method[32] = "CONNECT";
+									
+									strcat(uri, "Proxy-Authorization: Digest ");
+									
+									char* auth_string;
+									
+									if(strncmp(pa->qop, "auth", 5) == 0){
+										/* prepare a random string for cnounce */
+										char cnonce[17];
+										snprintf(cnonce, sizeof(cnonce), "%08x%08x", red_randui32(), red_randui32());
+										
+										if(strncmp(prev_nonce, pa->nonce, 32) == 0)nc++;
+										else{
+											strncpy(prev_nonce, pa->nonce, 32);
+											nc = 1;
+										}
+										
+										char str_nc[17];
+										snprintf(str_nc, sizeof(str_nc), "%08x", nc);
+										
+										auth_string = digest_authentication_encode(
+												user, pa->realm, passwd, //user, realm, pass
+												method, uri_path, str_nc, pa->nonce, cnonce, pa->qop); // method, path, nc, cnonce, qop
+									}
+									else{
+										auth_string = digest_authentication_encode(
+												user, pa->realm, passwd, //user, realm, pass
+												method, uri_path, NULL, pa->nonce, NULL, NULL); // method, path, nc, cnonce, qop
+										
+									}
+									strcat(uri, auth_string);
+									strcat(uri, linefeed);
+									
+									//char user_agent[256] = "User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:57.0) Gecko/20100101 Firefox/57.0";
+									//strncat(uri, user_agent, sizeof(uri) - strlen(uri) - 1);
+									
+									strcat(uri, linefeed);
+								}
+								else{
+									fprintf(stderr, "Error: User and password missing\n");
+									exit(-1);
+								}
+								
+								sent = 0;
+								if(debug & 1)fprintf(stderr, "DEBUG: done digest\n");
+								
+								if(strstr(buffer, "Connection: close") != NULL){
+									// necesary to open new socket, although the proxy should not do this
+									close(csock);
+									csock = sock_connect(host, port);
+									if(csock == -1) {
+										fprintf(stderr, "Error: Couldn't establish connection to proxy: %s\n", strerror(errno));
+										exit(-1);
+									}
+									reading = 0;
+								}
+								
+							}
+							else if(strstr(buffer, "Basic realm") != NULL){
+								if(debug & 1)fprintf(stderr, "DEBUG: Basic auth needed\n");
+								
+								memset(uri, 0, sizeof(uri));
+								
+								strcat(uri, "CONNECT ");
+								strcat(uri, uri_path);
+								strcat(uri, " HTTP/1.1");
+								strcat(uri, linefeed);
+								
+								if ((argc == 6) || (argc == 7)) {
+									strcat(uri, "Proxy-Authorization: Basic ");
+									strcat(uri, base64_encode(up));
+								}
+								else{
+									fprintf(stderr, "Error: User and password missing\n");
+									exit(-1);
+								}
+								strcat(uri, linefeed);
+								strcat(uri, linefeed);
+								
+								sent = 0;
+								// just in case because old socket not needed, and old HTTP/1.0 proxies may not send Connection: close header
+								close(csock);
+								csock = sock_connect(host, port);
+								if(csock == -1) {
+									fprintf(stderr, "Error: Couldn't establish connection to proxy: %s\n", strerror(errno));
+									exit(-1);
+								}
+								reading = 0;
+							}
+							
+							else{
+								fprintf(stderr, "Error: Proxy could not open connnection to %s: %s\n", desthost, descr);
+								exit(-1);
+							}
+							
+							continue;
+						}
+						fprintf(stderr, "Error: Proxy could not open connnection to %s: %s\n", desthost, descr);
 						exit(-1);
 					}
 				}
 			}
 			if (FD_ISSET(csock, &sfd) && (sent == 0)) {
+				reading = 0;
 				len = write(csock, uri, strlen(uri));
-				if (len<=0)
+				if(debug & 1)fprintf(stderr, "DEBUG: uri = \n%s\n", uri);
+				if (len <= 0)
 					break;
-				else
+				else{
+					if(debug & 1)fprintf(stderr, "DEBUG: sent uri\n");
 					sent = 1;
+				}
 			}
 		} else {
+			if(debug & 1)fprintf(stderr, "DEBUG: working\n");
 			if (FD_ISSET(csock, &rfd)) {
 				len = read(csock, buffer, sizeof(buffer));
+				if(debug & 2)fprintf(stderr, "DEBUG: buffer = %s\n", buffer);
 				if (len<=0) break;
 				len = write(1, buffer, len);
 				if (len<=0) break;
@@ -281,6 +602,7 @@ char *argv[];
 
 			if (FD_ISSET(0, &rfd)) {
 				len = read(0, buffer, sizeof(buffer));
+				if(debug & 2)fprintf(stderr, "DEBUG: buffer = %s\n", buffer);
 				if (len<=0) break;
 				len = write(csock, buffer, len);
 				if (len<=0) break;

--- a/md5.c
+++ b/md5.c
@@ -1,0 +1,377 @@
+/*
+  Copyright (C) 1999, 2000, 2002 Aladdin Enterprises.  All rights reserved.
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  L. Peter Deutsch
+  ghost@aladdin.com
+
+ */
+/* $Id: md5.c,v 1.6 2002/04/13 19:20:28 lpd Exp $ */
+/*
+  Independent implementation of MD5 (RFC 1321).
+
+  This code implements the MD5 Algorithm defined in RFC 1321, whose
+  text is available at
+	http://www.ietf.org/rfc/rfc1321.txt
+  The code is derived from the text of the RFC, including the test suite
+  (section A.5) but excluding the rest of Appendix A.  It does not include
+  any code or documentation that is identified in the RFC as being
+  copyrighted.
+
+  The original and principal author of md5.c is L. Peter Deutsch
+  <ghost@aladdin.com>.  Other authors are noted in the change history
+  that follows (in reverse chronological order):
+
+  2002-04-13 lpd Clarified derivation from RFC 1321; now handles byte order
+	either statically or dynamically; added missing #include <string.h>
+	in library.
+  2002-03-11 lpd Corrected argument list for main(), and added int return
+	type, in test program and T value program.
+  2002-02-21 lpd Added missing #include <stdio.h> in test program.
+  2000-07-03 lpd Patched to eliminate warnings about "constant is
+	unsigned in ANSI C, signed in traditional"; made test program
+	self-checking.
+  1999-11-04 lpd Edited comments slightly for automatic TOC extraction.
+  1999-10-18 lpd Fixed typo in header comment (ansi2knr rather than md5).
+  1999-05-03 lpd Original version.
+ */
+
+#include "md5.h"
+#include <string.h>
+
+#undef BYTE_ORDER	/* 1 = big-endian, -1 = little-endian, 0 = unknown */
+#ifdef ARCH_IS_BIG_ENDIAN
+#  define BYTE_ORDER (ARCH_IS_BIG_ENDIAN ? 1 : -1)
+#else
+#  define BYTE_ORDER 0
+#endif
+
+#define T_MASK ((md5_word_t)~0)
+#define T1 /* 0xd76aa478 */ (T_MASK ^ 0x28955b87)
+#define T2 /* 0xe8c7b756 */ (T_MASK ^ 0x173848a9)
+#define T3    0x242070db
+#define T4 /* 0xc1bdceee */ (T_MASK ^ 0x3e423111)
+#define T5 /* 0xf57c0faf */ (T_MASK ^ 0x0a83f050)
+#define T6    0x4787c62a
+#define T7 /* 0xa8304613 */ (T_MASK ^ 0x57cfb9ec)
+#define T8 /* 0xfd469501 */ (T_MASK ^ 0x02b96afe)
+#define T9    0x698098d8
+#define T10 /* 0x8b44f7af */ (T_MASK ^ 0x74bb0850)
+#define T11 /* 0xffff5bb1 */ (T_MASK ^ 0x0000a44e)
+#define T12 /* 0x895cd7be */ (T_MASK ^ 0x76a32841)
+#define T13    0x6b901122
+#define T14 /* 0xfd987193 */ (T_MASK ^ 0x02678e6c)
+#define T15 /* 0xa679438e */ (T_MASK ^ 0x5986bc71)
+#define T16    0x49b40821
+#define T17 /* 0xf61e2562 */ (T_MASK ^ 0x09e1da9d)
+#define T18 /* 0xc040b340 */ (T_MASK ^ 0x3fbf4cbf)
+#define T19    0x265e5a51
+#define T20 /* 0xe9b6c7aa */ (T_MASK ^ 0x16493855)
+#define T21 /* 0xd62f105d */ (T_MASK ^ 0x29d0efa2)
+#define T22    0x02441453
+#define T23 /* 0xd8a1e681 */ (T_MASK ^ 0x275e197e)
+#define T24 /* 0xe7d3fbc8 */ (T_MASK ^ 0x182c0437)
+#define T25    0x21e1cde6
+#define T26 /* 0xc33707d6 */ (T_MASK ^ 0x3cc8f829)
+#define T27 /* 0xf4d50d87 */ (T_MASK ^ 0x0b2af278)
+#define T28    0x455a14ed
+#define T29 /* 0xa9e3e905 */ (T_MASK ^ 0x561c16fa)
+#define T30 /* 0xfcefa3f8 */ (T_MASK ^ 0x03105c07)
+#define T31    0x676f02d9
+#define T32 /* 0x8d2a4c8a */ (T_MASK ^ 0x72d5b375)
+#define T33 /* 0xfffa3942 */ (T_MASK ^ 0x0005c6bd)
+#define T34 /* 0x8771f681 */ (T_MASK ^ 0x788e097e)
+#define T35    0x6d9d6122
+#define T36 /* 0xfde5380c */ (T_MASK ^ 0x021ac7f3)
+#define T37 /* 0xa4beea44 */ (T_MASK ^ 0x5b4115bb)
+#define T38    0x4bdecfa9
+#define T39 /* 0xf6bb4b60 */ (T_MASK ^ 0x0944b49f)
+#define T40 /* 0xbebfbc70 */ (T_MASK ^ 0x4140438f)
+#define T41    0x289b7ec6
+#define T42 /* 0xeaa127fa */ (T_MASK ^ 0x155ed805)
+#define T43 /* 0xd4ef3085 */ (T_MASK ^ 0x2b10cf7a)
+#define T44    0x04881d05
+#define T45 /* 0xd9d4d039 */ (T_MASK ^ 0x262b2fc6)
+#define T46 /* 0xe6db99e5 */ (T_MASK ^ 0x1924661a)
+#define T47    0x1fa27cf8
+#define T48 /* 0xc4ac5665 */ (T_MASK ^ 0x3b53a99a)
+#define T49 /* 0xf4292244 */ (T_MASK ^ 0x0bd6ddbb)
+#define T50    0x432aff97
+#define T51 /* 0xab9423a7 */ (T_MASK ^ 0x546bdc58)
+#define T52 /* 0xfc93a039 */ (T_MASK ^ 0x036c5fc6)
+#define T53    0x655b59c3
+#define T54 /* 0x8f0ccc92 */ (T_MASK ^ 0x70f3336d)
+#define T55 /* 0xffeff47d */ (T_MASK ^ 0x00100b82)
+#define T56 /* 0x85845dd1 */ (T_MASK ^ 0x7a7ba22e)
+#define T57    0x6fa87e4f
+#define T58 /* 0xfe2ce6e0 */ (T_MASK ^ 0x01d3191f)
+#define T59 /* 0xa3014314 */ (T_MASK ^ 0x5cfebceb)
+#define T60    0x4e0811a1
+#define T61 /* 0xf7537e82 */ (T_MASK ^ 0x08ac817d)
+#define T62 /* 0xbd3af235 */ (T_MASK ^ 0x42c50dca)
+#define T63    0x2ad7d2bb
+#define T64 /* 0xeb86d391 */ (T_MASK ^ 0x14792c6e)
+
+
+static void md5_process(md5_state_t *pms, const md5_byte_t *data /*[64]*/)
+{
+	md5_word_t
+		a = pms->abcd[0], b = pms->abcd[1],
+		c = pms->abcd[2], d = pms->abcd[3];
+	md5_word_t t;
+#if BYTE_ORDER > 0
+	/* Define storage only for big-endian CPUs. */
+	md5_word_t X[16];
+#else
+	/* Define storage for little-endian or both types of CPUs. */
+	md5_word_t xbuf[16];
+	const md5_word_t *X;
+#endif
+
+	{
+#if BYTE_ORDER == 0
+		/*
+		 * Determine dynamically whether this is a big-endian or
+		 * little-endian machine, since we can use a more efficient
+		 * algorithm on the latter.
+		 */
+		static const int w = 1;
+
+		if (*((const md5_byte_t *)&w)) /* dynamic little-endian */
+#endif
+#if BYTE_ORDER <= 0		/* little-endian */
+		{
+			/*
+			 * On little-endian machines, we can process properly aligned
+			 * data without copying it.
+			 */
+			if (!((data - (const md5_byte_t *)0) & 3)) {
+				/* data are properly aligned */
+				X = (const md5_word_t *)data;
+			} else {
+				/* not aligned */
+				memcpy(xbuf, data, 64);
+				X = xbuf;
+			}
+		}
+#endif
+#if BYTE_ORDER == 0
+		else			/* dynamic big-endian */
+#endif
+#if BYTE_ORDER >= 0		/* big-endian */
+		{
+			/*
+			 * On big-endian machines, we must arrange the bytes in the
+			 * right order.
+			 */
+			const md5_byte_t *xp = data;
+			int i;
+
+#  if BYTE_ORDER == 0
+			X = xbuf;		/* (dynamic only) */
+#  else
+#    define xbuf X		/* (static only) */
+#  endif
+			for (i = 0; i < 16; ++i, xp += 4)
+				xbuf[i] = xp[0] + (xp[1] << 8) + (xp[2] << 16) + (xp[3] << 24);
+		}
+#endif
+	}
+
+#define ROTATE_LEFT(x, n) (((x) << (n)) | ((x) >> (32 - (n))))
+
+	/* Round 1. */
+	/* Let [abcd k s i] denote the operation
+	   a = b + ((a + F(b,c,d) + X[k] + T[i]) <<< s). */
+#define F(x, y, z) (((x) & (y)) | (~(x) & (z)))
+#define SET(a, b, c, d, k, s, Ti)\
+	t = a + F(b,c,d) + X[k] + Ti;\
+	a = ROTATE_LEFT(t, s) + b
+	/* Do the following 16 operations. */
+	SET(a, b, c, d,  0,  7,  T1);
+	SET(d, a, b, c,  1, 12,  T2);
+	SET(c, d, a, b,  2, 17,  T3);
+	SET(b, c, d, a,  3, 22,  T4);
+	SET(a, b, c, d,  4,  7,  T5);
+	SET(d, a, b, c,  5, 12,  T6);
+	SET(c, d, a, b,  6, 17,  T7);
+	SET(b, c, d, a,  7, 22,  T8);
+	SET(a, b, c, d,  8,  7,  T9);
+	SET(d, a, b, c,  9, 12, T10);
+	SET(c, d, a, b, 10, 17, T11);
+	SET(b, c, d, a, 11, 22, T12);
+	SET(a, b, c, d, 12,  7, T13);
+	SET(d, a, b, c, 13, 12, T14);
+	SET(c, d, a, b, 14, 17, T15);
+	SET(b, c, d, a, 15, 22, T16);
+#undef SET
+
+	/* Round 2. */
+	/* Let [abcd k s i] denote the operation
+	   a = b + ((a + G(b,c,d) + X[k] + T[i]) <<< s). */
+#define G(x, y, z) (((x) & (z)) | ((y) & ~(z)))
+#define SET(a, b, c, d, k, s, Ti)\
+	t = a + G(b,c,d) + X[k] + Ti;\
+	a = ROTATE_LEFT(t, s) + b
+	/* Do the following 16 operations. */
+	SET(a, b, c, d,  1,  5, T17);
+	SET(d, a, b, c,  6,  9, T18);
+	SET(c, d, a, b, 11, 14, T19);
+	SET(b, c, d, a,  0, 20, T20);
+	SET(a, b, c, d,  5,  5, T21);
+	SET(d, a, b, c, 10,  9, T22);
+	SET(c, d, a, b, 15, 14, T23);
+	SET(b, c, d, a,  4, 20, T24);
+	SET(a, b, c, d,  9,  5, T25);
+	SET(d, a, b, c, 14,  9, T26);
+	SET(c, d, a, b,  3, 14, T27);
+	SET(b, c, d, a,  8, 20, T28);
+	SET(a, b, c, d, 13,  5, T29);
+	SET(d, a, b, c,  2,  9, T30);
+	SET(c, d, a, b,  7, 14, T31);
+	SET(b, c, d, a, 12, 20, T32);
+#undef SET
+
+	/* Round 3. */
+	/* Let [abcd k s t] denote the operation
+	   a = b + ((a + H(b,c,d) + X[k] + T[i]) <<< s). */
+#define H(x, y, z) ((x) ^ (y) ^ (z))
+#define SET(a, b, c, d, k, s, Ti)\
+	t = a + H(b,c,d) + X[k] + Ti;\
+	a = ROTATE_LEFT(t, s) + b
+	/* Do the following 16 operations. */
+	SET(a, b, c, d,  5,  4, T33);
+	SET(d, a, b, c,  8, 11, T34);
+	SET(c, d, a, b, 11, 16, T35);
+	SET(b, c, d, a, 14, 23, T36);
+	SET(a, b, c, d,  1,  4, T37);
+	SET(d, a, b, c,  4, 11, T38);
+	SET(c, d, a, b,  7, 16, T39);
+	SET(b, c, d, a, 10, 23, T40);
+	SET(a, b, c, d, 13,  4, T41);
+	SET(d, a, b, c,  0, 11, T42);
+	SET(c, d, a, b,  3, 16, T43);
+	SET(b, c, d, a,  6, 23, T44);
+	SET(a, b, c, d,  9,  4, T45);
+	SET(d, a, b, c, 12, 11, T46);
+	SET(c, d, a, b, 15, 16, T47);
+	SET(b, c, d, a,  2, 23, T48);
+#undef SET
+
+	/* Round 4. */
+	/* Let [abcd k s t] denote the operation
+	   a = b + ((a + I(b,c,d) + X[k] + T[i]) <<< s). */
+#define I(x, y, z) ((y) ^ ((x) | ~(z)))
+#define SET(a, b, c, d, k, s, Ti)\
+	t = a + I(b,c,d) + X[k] + Ti;\
+	a = ROTATE_LEFT(t, s) + b
+	/* Do the following 16 operations. */
+	SET(a, b, c, d,  0,  6, T49);
+	SET(d, a, b, c,  7, 10, T50);
+	SET(c, d, a, b, 14, 15, T51);
+	SET(b, c, d, a,  5, 21, T52);
+	SET(a, b, c, d, 12,  6, T53);
+	SET(d, a, b, c,  3, 10, T54);
+	SET(c, d, a, b, 10, 15, T55);
+	SET(b, c, d, a,  1, 21, T56);
+	SET(a, b, c, d,  8,  6, T57);
+	SET(d, a, b, c, 15, 10, T58);
+	SET(c, d, a, b,  6, 15, T59);
+	SET(b, c, d, a, 13, 21, T60);
+	SET(a, b, c, d,  4,  6, T61);
+	SET(d, a, b, c, 11, 10, T62);
+	SET(c, d, a, b,  2, 15, T63);
+	SET(b, c, d, a,  9, 21, T64);
+#undef SET
+
+	/* Then perform the following additions. (That is increment each
+	   of the four registers by the value it had before this block
+	   was started.) */
+	pms->abcd[0] += a;
+	pms->abcd[1] += b;
+	pms->abcd[2] += c;
+	pms->abcd[3] += d;
+}
+
+void md5_init(md5_state_t *pms)
+{
+	pms->count[0] = pms->count[1] = 0;
+	pms->abcd[0] = 0x67452301;
+	pms->abcd[1] = /*0xefcdab89*/ T_MASK ^ 0x10325476;
+	pms->abcd[2] = /*0x98badcfe*/ T_MASK ^ 0x67452301;
+	pms->abcd[3] = 0x10325476;
+}
+
+void md5_append(md5_state_t *pms, const md5_byte_t *data, int nbytes)
+{
+	const md5_byte_t *p = data;
+	int left = nbytes;
+	int offset = (pms->count[0] >> 3) & 63;
+	md5_word_t nbits = (md5_word_t)(nbytes << 3);
+
+	if (nbytes <= 0)
+		return;
+
+	/* Update the message length. */
+	pms->count[1] += nbytes >> 29;
+	pms->count[0] += nbits;
+	if (pms->count[0] < nbits)
+		pms->count[1]++;
+
+	/* Process an initial partial block. */
+	if (offset) {
+		int copy = (offset + nbytes > 64 ? 64 - offset : nbytes);
+
+		memcpy(pms->buf + offset, p, copy);
+		if (offset + copy < 64)
+			return;
+		p += copy;
+		left -= copy;
+		md5_process(pms, pms->buf);
+	}
+
+	/* Process full blocks. */
+	for (; left >= 64; p += 64, left -= 64)
+		md5_process(pms, p);
+
+	/* Process a final partial block. */
+	if (left)
+		memcpy(pms->buf, p, left);
+}
+
+void md5_finish(md5_state_t *pms, md5_byte_t digest[16])
+{
+	static const md5_byte_t pad[64] = {
+		0x80, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+	};
+	md5_byte_t data[8];
+	int i;
+
+	/* Save the length before padding. */
+	for (i = 0; i < 8; ++i)
+		data[i] = (md5_byte_t)(pms->count[i >> 2] >> ((i & 3) << 3));
+	/* Pad to 56 bytes mod 64. */
+	md5_append(pms, pad, ((55 - (pms->count[0] >> 3)) & 63) + 1);
+	/* Append the length. */
+	md5_append(pms, data, 8);
+	for (i = 0; i < 16; ++i)
+		digest[i] = (md5_byte_t)(pms->abcd[i >> 2] >> ((i & 3) << 3));
+}

--- a/md5.h
+++ b/md5.h
@@ -1,0 +1,91 @@
+/*
+  Copyright (C) 1999, 2002 Aladdin Enterprises.  All rights reserved.
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  L. Peter Deutsch
+  ghost@aladdin.com
+
+ */
+/* $Id: md5.h,v 1.4 2002/04/13 19:20:28 lpd Exp $ */
+/*
+  Independent implementation of MD5 (RFC 1321).
+
+  This code implements the MD5 Algorithm defined in RFC 1321, whose
+  text is available at
+	http://www.ietf.org/rfc/rfc1321.txt
+  The code is derived from the text of the RFC, including the test suite
+  (section A.5) but excluding the rest of Appendix A.  It does not include
+  any code or documentation that is identified in the RFC as being
+  copyrighted.
+
+  The original and principal author of md5.h is L. Peter Deutsch
+  <ghost@aladdin.com>.  Other authors are noted in the change history
+  that follows (in reverse chronological order):
+
+  2002-04-13 lpd Removed support for non-ANSI compilers; removed
+	references to Ghostscript; clarified derivation from RFC 1321;
+	now handles byte order either statically or dynamically.
+  1999-11-04 lpd Edited comments slightly for automatic TOC extraction.
+  1999-10-18 lpd Fixed typo in header comment (ansi2knr rather than md5);
+	added conditionalization for C++ compilation from Martin
+	Purschke <purschke@bnl.gov>.
+  1999-05-03 lpd Original version.
+ */
+
+#ifndef md5_INCLUDED
+#  define md5_INCLUDED
+
+/*
+ * This package supports both compile-time and run-time determination of CPU
+ * byte order.  If ARCH_IS_BIG_ENDIAN is defined as 0, the code will be
+ * compiled to run only on little-endian CPUs; if ARCH_IS_BIG_ENDIAN is
+ * defined as non-zero, the code will be compiled to run only on big-endian
+ * CPUs; if ARCH_IS_BIG_ENDIAN is not defined, the code will be compiled to
+ * run on either big- or little-endian CPUs, but will run slightly less
+ * efficiently on either one than if ARCH_IS_BIG_ENDIAN is defined.
+ */
+
+typedef unsigned char md5_byte_t; /* 8-bit byte */
+typedef unsigned int md5_word_t; /* 32-bit word */
+
+/* Define the state of the MD5 Algorithm. */
+typedef struct md5_state_s {
+    md5_word_t count[2];	/* message length in bits, lsw first */
+    md5_word_t abcd[4];		/* digest buffer */
+    md5_byte_t buf[64];		/* accumulate block */
+} md5_state_t;
+
+#ifdef __cplusplus
+extern "C" 
+{
+#endif
+
+/* Initialize the algorithm. */
+void md5_init(md5_state_t *pms);
+
+/* Append a string to the message. */
+void md5_append(md5_state_t *pms, const md5_byte_t *data, int nbytes);
+
+/* Finish the message and return the digest. */
+void md5_finish(md5_state_t *pms, md5_byte_t digest[16]);
+
+#ifdef __cplusplus
+}  /* end extern "C" */
+#endif
+
+#endif /* md5_INCLUDED */


### PR DESCRIPTION
Added support for digest auth. Only the essential parts of RFC 7616 are implemented. I tested this with Squid proxy only, using no auth, basic and digest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Integrated MD5 hashing for enhanced security.
  - Implemented additional authentication mechanisms.

- **Enhancements**
  - Improved random number generation for internal processes.

- **Refactor**
  - Optimized various functions for better performance and maintainability.

- **Dependencies**
  - Now utilizing `libevent` for efficient event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->